### PR TITLE
Typo error corrected for the key ServiceComponent under the Tags section to have the correct name i.e. applicationServer

### DIFF
--- a/layer4-openvpn/service-openvpn-access-server.yaml
+++ b/layer4-openvpn/service-openvpn-access-server.yaml
@@ -419,7 +419,7 @@ Resources:
           Value: "openVPN"
         -
           Key: "ServiceComponent"
-          Value: "applicationService"
+          Value: "applicationServer"
         -
           Key: "NetworkTier"
           Value: "public"


### PR DESCRIPTION
As suggested, Creating a PR Request to correct the typo error.