### PR TITLE
Added the volume details to /etc/fstab which will make sure the volum…

### DIFF
--- a/layer2-adop-c/service-adop-c.yaml
+++ b/layer2-adop-c/service-adop-c.yaml
@@ -251,6 +251,8 @@ Resources:
           ln -s /mnt/docker-data /var/lib/docker
           ln -s /mnt/docker-volumes /var/lib/docker/volumes
           echo 'other_args="-g /mnt/docker-data"' >> /etc/sysconfig/docker
+          echo "/dev/xvdf /mnt/docker-data ext4 defaults 0 0" >> /etc/fstab
+          echo "/dev/xvdg /mnt/docker-volumes ext4 defaults 0 0" >> /etc/fstab
           
           echo '=========================== Configuring Docker Daemon ==========================='
           grep 'tcp://0.0.0.0:2375' /usr/lib/systemd/system/docker.service || sed -i 's#ExecStart\(.*\)$#ExecStart\1 -H unix:///var/run/docker.sock -H tcp://0.0.0.0:2375#' /usr/lib/systemd/system/docker.service


### PR DESCRIPTION
Whenever an additional storage is mounted on the ec2 instance, we need to add the details of the device and the mount location in /etc/fstab which will make sure that the volumes are mounted when the instance restarts. Hence added the above piece of code because of as today if we use the gen 5 template to spin up ADOP and then stop and start the instance the volumes gets detached.