### PR TITLE
Code for disabling SSLv3 in OpenVPN yaml file to avoid SOC Vulnerabilities

### DIFF
--- a/layer4-openvpn/service-openvpn-access-server.yaml
+++ b/layer4-openvpn/service-openvpn-access-server.yaml
@@ -387,7 +387,10 @@ Resources:
           if [ "$LDAP_GROUP_MEMBERSHIP" != "" ]; then
             /usr/local/openvpn_as/scripts/sacli --key auth.ldap.0.add_req --value $LDAP_GROUP_MEMBERSHIP ConfigPut
           fi
-
+          
+          # Setting WebServer SSL/TLS Options to TLSv1.2 to disable SSV3. This will avoid SOC Vulnerability related to OpenVPN
+          /usr/local/openvpn_as/scripts/sacli --key cs.tls_version_min --value 1.2 ConfigPut
+          
           /usr/local/openvpn_as/scripts/sacli --key vpn.server.session_ip_lock --value true ConfigPut
           /usr/local/openvpn_as/scripts/sacli --key vpn.server.lockout_policy.n_fails --value 3 ConfigPut
           /usr/local/openvpn_as/scripts/sacli --key vpn.server.lockout_policy.reset_time --value 900 ConfigPut


### PR DESCRIPTION
Added an extra configuration in User Data to disable SSLv3 and enable TLSv1.2 for OpenVPN Web Server. This will avoid poodle attacks and take care of SOC Vulnerabilities related to OpenVPN Server