### PR TITLE
Added policy for  EBSBackupLambdaRole

### DIFF
--- a/layer5-ebs-backups/ebs-backup-lambda-function.yaml
+++ b/layer5-ebs-backups/ebs-backup-lambda-function.yaml
@@ -27,7 +27,8 @@ Resources:
 
   EBSBackupLambdaRole:
     Type: "AWS::IAM::Role"
-    Properties: 
+    Properties:
+      RoleName: !Sub ebs-backup-lambda-role-${AWS::Region}
       AssumeRolePolicyDocument:
         Version: "2012-10-17"
         Statement:
@@ -39,8 +40,7 @@ Resources:
             Action:
               - "sts:AssumeRole"
       Path: "/"
-      ManagedPolicyArns:
-        - "arn:aws:iam::aws:policy/AWSLambdaFullAccess"      
+      
   EBSBackupLambdaPolicy:
     Type: "AWS::IAM::Policy"
     Properties:


### PR DESCRIPTION
 Removed the lambda full access managed role , created role name ebs-backup-lambda-role and attached the policy for the issue [https://github.com/Accenture/adop-aws/issues/5](5)
@kramos can change all  cf template with SAM , happy to help if required